### PR TITLE
Fix syntax error in linbo-cloop2qcow2

### DIFF
--- a/serverfs/usr/sbin/linbo-cloop2qcow2
+++ b/serverfs/usr/sbin/linbo-cloop2qcow2
@@ -29,7 +29,7 @@ if [ ! -s "$CLOOPFILE" -o "${CLOOPFILE##*.}" != "cloop" ]; then
 fi
 
 # check output directory
-if [ -n "$2"]; then
+if [ -n "$2" ]; then
   if [ -d "$2" ]; then
     TARGETDIR="$2"
   else


### PR DESCRIPTION
Fix syntax error in linbo-cloop2qcow2
Fixes #5 