### PR TITLE
fix parts of the patch_registry script

### DIFF
--- a/linbofs/bin/patch_registry
+++ b/linbofs/bin/patch_registry
@@ -71,7 +71,7 @@ create_fullkey() {
 
  [ -n "$DEBUG" ] && echo " 5 key=$key" | tee -a $logfile
  # remove right end and replace it with a backslash
- key=`rightchopend "$key"`
+ key=$(rightchopend "$key")
  local fullpath="$key"
 
  [ -n "$DEBUG" ] && echo " 6 fullpath=$fullpath" | tee -a $logfile
@@ -125,7 +125,7 @@ create_command() {
 
  local key="$1"
  local change="$2"
- local fullpath=`rightchopend "$key"`
+ local fullpath=$(rightchopend "$key")
 
  [ -n "$DEBUG" ] && echo " 7 change=$change" | tee -a $logfile
 
@@ -197,12 +197,12 @@ while read -r line; do
    tkey="$(leftchop "$line")"
    [ -n "$DEBUG" ] && echo " 1 tkey=$tkey" | tee -a $logfile
 
-   case `leftget "$tkey"` in
+   case "$(leftget "$tkey")" in
     [Ss][Yy][Ss][Tt][Ee][Mm]*) 
      hive="$(ls -1d $2/[Ww][Ii][Nn][Dd][Oo][Ww][Ss]/[Ss][Yy][Ss][Tt][Ee][Mm]32/[Cc][Oo][Nn][Ff][Ii][Gg]/[Ss][Yy][Ss][Tt][Ee][Mm] 2>/dev/null | tail -1)"
      [ -z "$hive" ] && hive="$(ls -1d $2/[Ww][Ii][Nn][Nn][Tt]/[Ss][Yy][Ss][Tt][Ee][Mm]32/[Cc][Oo][Nn][Ff][Ii][Gg]/[Ss][Yy][Ss][Tt][Ee][Mm] 2>/dev/null | tail -1)"
      # strip hive
-     key=`leftchop "$tkey"`
+     key="$(leftchop "$tkey")"
      [ -n "$DEBUG" ] && echo " 2 key=$key" | tee -a $logfile
 
      # change "CurrentControlSet" to "ControlSet001"
@@ -213,7 +213,7 @@ while read -r line; do
      hive="$(ls -1d $2/[Ww][Ii][Nn][Dd][Oo][Ww][Ss]/[Ss][Yy][Ss][Tt][Ee][Mm]32/[Cc][Oo][Nn][Ff][Ii][Gg]/[Ss][Oo][Ff][Tt][Ww][Aa][Rr][Ee] 2>/dev/null | tail -1)"
      [ -z "$hive" ] && hive="$(ls -1d $2/[Ww][Ii][Nn][Nn][Tt]/[Ss][Yy][Ss][Tt][Ee][Mm]32/[Cc][Oo][Nn][Ff][Ii][Gg]/[Ss][Oo][Ff][Tt][Ww][Aa][Rr][Ee] 2>/dev/null | tail -1)"
      # strip hive
-     key=`leftchop "$tkey"`
+     key="$(leftchop "$tkey")"
      [ -n "$DEBUG" ] && echo " 4 key=$key" | tee -a $logfile
      ;;
     *) key="" ;;
@@ -251,7 +251,7 @@ while read -r line; do
    for i in ControlSet002 ControlSet003; do
     echo "### Checking $i ..."
 	   if [ -n "$(test_key "" "$i")" ]; then
-	    key_new=`echo "$key" | sed -e "s|ControlSet001|$i|"`
+	    key_new="$(echo "$key" | sed -e "s|ControlSet001|$i|")"
 	    [ -n "$DEBUG" ] && echo "### Patching $i ..." | tee -a $logfile
      create_command "$key_new" "$line"
 	   fi

--- a/linbofs/bin/patch_registry
+++ b/linbofs/bin/patch_registry
@@ -35,7 +35,7 @@ leftgetvalue(){
 }
 
 rightgetvalue(){
-  echo "$1" | cut -d \= -f 2
+  echo ${1#*=}
 }
 
 rightchopend(){

--- a/linbofs/bin/patch_registry
+++ b/linbofs/bin/patch_registry
@@ -190,8 +190,24 @@ create_command() {
 # remove carriage returns
 dos2unix $1
 
+# define append variable
+append=false
+
 # read patch file
 while read -r line; do
+ # join value lines ending in backslash
+ if [ "${line##*,}" = "\\" ]; then
+  append=true
+  append_line="${append_line}${line%,*},"
+  continue
+ else
+  if [ "$append"=true ]; then
+   line="${append_line}$line"
+   append_line=
+   append=false
+  fi
+ fi
+
  [ -n "$DEBUG" ] && echo "$line $((count++))" | tee -a $logfile
 
  # select hive for patching

--- a/linbofs/bin/patch_registry
+++ b/linbofs/bin/patch_registry
@@ -187,6 +187,9 @@ create_command() {
  exec_command "$command"
 }
 
+# remove carriage returns
+dos2unix $1
+
 # read patch file
 while read -r line; do
  [ -n "$DEBUG" ] && echo "$line $((count++))" | tee -a $logfile


### PR DESCRIPTION
As discussed in issue #50 this fixes some problems in the patch_registry script. Sadly for very long key values it still doesn't work, as reged itself cuts off things, if it deems them too long.

Also the fact that only String and DWord values are supported remains unchanged.