### PR TITLE
Added basic multischoolsupport in linbo_helperfunctions.sh

### DIFF
--- a/serverfs/usr/share/linuxmuster/linbo/helperfunctions.sh
+++ b/serverfs/usr/share/linuxmuster/linbo/helperfunctions.sh
@@ -118,7 +118,12 @@ END
 # return hostgroup of device from devices.csv
 # get_hostgroup hostname
 get_hostgroup(){
-  $LDBSEARCH "(sophomorixDnsNodename="$(tolower $1)")" memberOf | grep ,OU=device-groups, | awk -F= '{print $2}' | awk -F, '{print $1}' | sed 's|^d_||'
+  schoolprefix=$($LDBSEARCH "(sophomorixDnsNodename="$(tolower $1)")" sophomorixSchoolPrefix | grep sophomorixSchoolPrefix | awk '{print $2}')
+  if [ "$schoolprefix" == "---" ]; then
+    $LDBSEARCH "(sophomorixDnsNodename="$(tolower $1)")" memberOf | grep ,OU=device-groups, | awk -F= '{print $2}' | awk -F, '{print $1}' | sed 's|^d_||'
+  else
+    $LDBSEARCH "(sophomorixDnsNodename="$(tolower $1)")" memberOf | grep ,OU=device-groups, | awk -F= '{print $2}' | awk -F, '{print $1}' | sed "s|^d_${schoolprefix}-||"
+  fi
 }
 
 # return mac address from dhcp leases


### PR DESCRIPTION
Reading the start.conf group from the LDAP Groups has the disadvantage that we've to determine the correct filename. First we've to get rid of the d_ prefix. Furthermore we've to remove the shortname school prefix in multischool.

This works but I would suggest saving the connected start.conf in a sophomorix LDAP field, so we could simply do something like this:
`
$LDBSEARCH "(sophomorixDnsNodename="$(tolower $1)")" sophomorixCustom1 | grep sophomorixCustom1 | awk '{print $2}'`

I think this would be a bit more straight forward. 