### PR TITLE
fixed macct name generation for qcow2 in linbo_cmd

### DIFF
--- a/linbofs/usr/bin/linbo_cmd
+++ b/linbofs/usr/bin/linbo_cmd
@@ -1363,7 +1363,11 @@ invoke_macct(){
   # get image filename from start.conf
   for i in qcow2 cloop; do
     if grep -i ^baseimage /start.conf | grep -q "${imagebase}.${i}"; then
-      imagemacct="${imagebase}.${i}.macct"
+      if [ "$i" == "cloop" ]; then
+        imagemacct="${imagebase}.${i}.macct"
+      else
+        imagemacct="${imagebase}.macct"
+      fi
       break
     fi
   done


### PR DESCRIPTION
As mentioned in Issue #67 