### PR TITLE
Upstream lmn71

### DIFF
--- a/linbofs/init.sh
+++ b/linbofs/init.sh
@@ -572,7 +572,7 @@ network(){
       else
         dhcpdev="$dev"
       fi
-      udhcpc -n -i "$dhcpdev" $dhcpretry &> /dev/null ; RC="$?"
+      udhcpc -O nisdomain -n -i "$dhcpdev" $dhcpretry &> /dev/null ; RC="$?"
       if [ "$RC" = "0" ]; then
         # set mtu
         [ -n "$mtu" ] && ifconfig "$dev" mtu $mtu &> /dev/null
@@ -595,7 +595,7 @@ network(){
     print_status "linbo_server='$server'" >> /tmp/dhcp.log
     print_status "Loading configuration files from $server ..."
     # request host specific start.conf from server
-    rsync -L "$server::linbo/tmp/start.conf_$hostname" "/start.conf" &> /dev/null
+    rsync -L "$server::linbo/start.conf.$hostgroup" "/start.conf" &> /dev/null
     # set flag for working network connection and do additional stuff which needs
     # connection to linbo server
     if [ -s /start.conf ]; then

--- a/linbofs/usr/bin/linbo_cmd
+++ b/linbofs/usr/bin/linbo_cmd
@@ -1390,7 +1390,7 @@ invoke_macct(){
     fi
   done
   [ -z "$imagemacct" ] && return 1
-  local serverip="$(grep -m1 ^linbo_server= /tmp/dhcp.log | awk -F\' '{ print $2 }')"
+  local serverip="$(grep -m1 ^serverid= /tmp/dhcp.log | awk -F\' '{ print $2 }')"
   [ -z "$serverip" ] && return 1
   echo "Initiating machine password update on server $serverip ..."
   download "$serverip" "$imagemacct"


### PR DESCRIPTION
Use nis-domain to determine linbo group which streamlines the process of getting the linbogroup.

Also use serverid instead of linbo_server for macct handling.
This is important when the server offering linbofs is not the same as the linuxmuster server. (Used another server via kernel parameter in start.conf)