### PR TITLE
Disable filling with zeros on image creation

### DIFF
--- a/linbofs/usr/bin/linbo_create_image
+++ b/linbofs/usr/bin/linbo_create_image
@@ -117,19 +117,19 @@ prepare_fs(){
 mk_baseimage(){
   local rootdev="$1"
   local imagefile="$2"
-  echo "Filling up partition with zeroes..." | tee -a /tmp/image.log
-  # Create nulled files of size 1GB, should work on any FS.
-  local count=0
-  while true; do
-    # tschmitt: log errors to image.log
-    interruptible dd if=/dev/zero of="/mnt/zero$count.tmp" bs=1024k count=1000 2>>/tmp/image.log || break
-    [ -s "/mnt/zero$count.tmp" ] || break
-    let count++
-    echo "$(du -ch /mnt/zero*.tmp | tail -1 | awk '{ print $1 }') zeroed ... " | tee -a /tmp/image.log
-  done
-  # Sync is asynchronous, unless started twice at least.
+  # echo "Filling up partition with zeroes..." | tee -a /tmp/image.log
+  # # Create nulled files of size 1GB, should work on any FS.
+  # local count=0
+  # while true; do
+  #   # tschmitt: log errors to image.log
+  #   interruptible dd if=/dev/zero of="/mnt/zero$count.tmp" bs=1024k count=1000 2>>/tmp/image.log || break
+  #   [ -s "/mnt/zero$count.tmp" ] || break
+  #   let count++
+  #   echo "$(du -ch /mnt/zero*.tmp | tail -1 | awk '{ print $1 }') zeroed ... " | tee -a /tmp/image.log
+  # done
+  # # Sync is asynchronous, unless started twice at least.
   sync ; sync ; sync
-  rm -f /mnt/zero*.tmp
+  # rm -f /mnt/zero*.tmp
   umount /mnt || umount -l /mnt
   echo "Starting compression of $rootdev -> $imagefile (full partition, ${size}K)."
   echo "qemu-img convert -p -c -f raw -O qcow2 $rootdev $imagefile"


### PR DESCRIPTION
After some tests with imaging in version 7.2 we found an error in image creation. The process runs successfully, but the qcow image is broken and cannot be restored or mounted with nbd. When running the qcow-img command manually, the created image is fully working and restorable.

So the solution is to disable the part where the partition is filling with zeros. I think this part is not necessary anymore. 