### PR TITLE
Update stable kernel to 6.9 and fix kernel build

### DIFF
--- a/build/conf.d/10_r8812
+++ b/build/conf.d/10_r8812
@@ -1,4 +1,4 @@
-# r8168 build environment
+# r8812au build environment
 #
 # thomas@linuxmuster.net
 # 20231202
@@ -6,5 +6,5 @@
 
 # module source
 R8812NAME="8812au"
-R8812GITNAME="$R8812NAME-20210629"
+R8812GITNAME="$R8812NAME-20210820"
 R8812GITURL="https://github.com/morrownr/${R8812GITNAME}.git"

--- a/build/conf.d/2_kernel-versions
+++ b/build/conf.d/2_kernel-versions
@@ -4,10 +4,10 @@
 # 20240123
 #
 
-STABLE="6.7"
+STABLE="6.9"
 LONGTERM="6.1"
 LEGACY="5.15"
 
 # get current versions from kernel.org
-KVERSIONS="$(wget -q https://kernel.org -O - | grep tarball | grep "linux-$STABLE\|linux-$LONGTERM\|linux-$LEGACY" | grep -o "$STABLE.[0-9]*\|$LONGTERM.[0-9]*\|$LEGACY.[0-9]*")"
+KVERSIONS="$(wget -q https://kernel.org -O - | grep tarball | grep "linux-$STABLE\.\|linux-$LONGTERM\.\|linux-$LEGACY\." | grep -o "$STABLE.[0-9]*\|$LONGTERM.[0-9]*\|$LEGACY.[0-9]*")"
 KVERSARRAY=($KVERSIONS)

--- a/build/patches/r8168/stable/02_fix_ethtool.patch
+++ b/build/patches/r8168/stable/02_fix_ethtool.patch
@@ -1,0 +1,119 @@
+From 94426e16197c244d03aad0434e3490acdaa830fe Mon Sep 17 00:00:00 2001
+From: Masato TOYOSHIMA <phoepsilonix@phoepsilonix.love>
+Date: Tue, 14 May 2024 14:52:58 +0900
+Subject: [PATCH] Linux 6.9 compat: change to ethtool_keee from ethtool_eee
+
+linux/include/linux/ethtool.h
+
+struct ethtool_ops
+    int (*get_eee)(struct net_device *dev, struct ethtool_keee *eee);
+    int (*set_eee)(struct net_device *dev, struct ethtool_keee *eee);
+
+change to ethtool_keee from ethtool_eee
+    rtl_ethtool_get_eee(struct net_device *net, struct ethtool_keee *edata)
+    rtl_ethtool_set_eee(struct net_device *net, struct ethtool_keee *edata)
+---
+ src/r8168_n.c | 44 ++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 44 insertions(+)
+
+diff --git a/src/r8168_n.c b/src/r8168_n.c
+index ad63f42..3d67641 100755
+--- a/src/r8168_n.c
++++ b/src/r8168_n.c
+@@ -7941,7 +7941,11 @@ rtl8168_device_lpi_t_to_ethtool_lpi_t(struct rtl8168_private *tp , u32 lpi_timer
+ }
+ 
+ static int
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0)
++rtl_ethtool_get_eee(struct net_device *net, struct ethtool_keee *edata)
++#else
+ rtl_ethtool_get_eee(struct net_device *net, struct ethtool_eee *edata)
++#endif
+ {
+         struct rtl8168_private *tp = netdev_priv(net);
+         struct ethtool_eee *eee = &tp->eee;
+@@ -7975,9 +7979,15 @@ rtl_ethtool_get_eee(struct net_device *net, struct ethtool_eee *edata)
+ 
+         edata->eee_enabled = !!val;
+         edata->eee_active = !!(supported & adv & lp);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0)
++        ethtool_convert_legacy_u32_to_link_mode(edata->supported, supported);
++        ethtool_convert_legacy_u32_to_link_mode(edata->advertised, adv);
++        ethtool_convert_legacy_u32_to_link_mode(edata->lp_advertised, lp);
++#else
+         edata->supported = supported;
+         edata->advertised = adv;
+         edata->lp_advertised = lp;
++#endif
+         edata->tx_lpi_enabled = edata->eee_enabled;
+         edata->tx_lpi_timer = tx_lpi_timer;
+ 
+@@ -7985,11 +7995,19 @@ rtl_ethtool_get_eee(struct net_device *net, struct ethtool_eee *edata)
+ }
+ 
+ static int
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0)
++rtl_ethtool_set_eee(struct net_device *net, struct ethtool_keee *edata)
++#else
+ rtl_ethtool_set_eee(struct net_device *net, struct ethtool_eee *edata)
++#endif
+ {
+         struct rtl8168_private *tp = netdev_priv(net);
+         struct ethtool_eee *eee = &tp->eee;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0)
++        u32 advertising, adv;
++#else
+         u32 advertising;
++#endif
+         int rc = 0;
+ 
+         if (!rtl8168_support_eee(tp))
+@@ -8013,6 +8031,18 @@ rtl_ethtool_set_eee(struct net_device *net, struct ethtool_eee *edata)
+         }
+ 
+         advertising = tp->advertising;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0)
++        ethtool_convert_link_mode_to_legacy_u32(&adv, edata->advertised);
++        if (linkmode_empty(edata->advertised)) {
++                adv = advertising & eee->supported;
++                ethtool_convert_legacy_u32_to_link_mode(edata->advertised, adv);
++        } else if (!linkmode_empty(edata->advertised) & ~advertising) {
++                dev_printk(KERN_WARNING, tp_to_dev(tp), "EEE advertised %x must be a subset of autoneg advertised speeds %x\n",
++                           adv, advertising);
++                rc = -EINVAL;
++                goto out;
++        }
++#else
+         if (!edata->advertised) {
+                 edata->advertised = advertising & eee->supported;
+         } else if (edata->advertised & ~advertising) {
+@@ -8021,15 +8051,29 @@ rtl_ethtool_set_eee(struct net_device *net, struct ethtool_eee *edata)
+                 rc = -EINVAL;
+                 goto out;
+         }
++#endif
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0)
++        if (!linkmode_empty(edata->advertised) & ~eee->supported) {
++                dev_printk(KERN_WARNING, tp_to_dev(tp), "EEE advertised %x must be a subset of support %x\n",
++                           adv, eee->supported);
++                rc = -EINVAL;
++                goto out;
++        }
++#else
+         if (edata->advertised & ~eee->supported) {
+                 dev_printk(KERN_WARNING, tp_to_dev(tp), "EEE advertised %x must be a subset of support %x\n",
+                            edata->advertised, eee->supported);
+                 rc = -EINVAL;
+                 goto out;
+         }
++#endif
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,9,0)
++        ethtool_convert_link_mode_to_legacy_u32(&eee->advertised, edata->advertised);
++#else
+         eee->advertised = edata->advertised;
++#endif
+         eee->eee_enabled = edata->eee_enabled;
+ 
+         if (eee->eee_enabled)

--- a/build/run.d/4_opentracker
+++ b/build/run.d/4_opentracker
@@ -10,12 +10,21 @@ if [ -s "$OTBIN" -a -x "$OTBIN" ]; then
   echo "Opentracker binary exists, skipping build."
 
 else
-  # download
+  # download dependency libowfat
+  echo "Download libowfat source..."
+  [ -d "$SRC/libowfat" ] && rm -rf "$SRC/libowfat"
+  cd "$SRC"
+  cvs -d :pserver:cvs@cvs.fefe.de:/cvs -z9 co libowfat || exit 1
+  # download opentracker
   echo "Cloning $OTNAME source ..."
   [ -d "$OTSRCDIR" ] && rm -rf "$OTSRCDIR"
   cd "$SRC"
   git clone "$OTURL" || exit 1
-  # compile
+  # compile dependency libowfat
+  cd $SRC/libowfat || exit 1
+  make || exit 1
+  cd "$SRC"
+  # compile opentracker
   echo "Compiling $OTNAME ..."
   cd "$OTSRCDIR" || exit 1
   make || exit 1

--- a/debian/control
+++ b/debian/control
@@ -3,12 +3,12 @@ Section: admin
 Priority: extra
 Maintainer: Thomas Schmitt <thomas@linuxmuster.net>
 Build-Depends: acl, argon2, bc, binutils, bison, build-essential, ctorrent,
-  curl, debianutils, debhelper, dosfstools, dpkg-dev, dropbear-bin,
+  curl, cvs, debianutils, debhelper, dosfstools, dpkg-dev, dropbear-bin,
   gcc-multilib, e2fsprogs, efibootmgr, ethtool, fakeroot, flex, fonts-ubuntu,
   g++, gcc, gdisk, gettext, git, gnupg2, gpgv2, grep, grub-common, grub-ipxe,
   grub-efi-amd64-bin, grub2-common, grub-pc-bin, gzip, hdparm, kmod,
   libacl1-dev, libattr1-dev, libelf-dev, libfuse-dev, libncurses5-dev,
-  libnih-dbus1, libowfat-dev, libssl-dev, linux-libc-dev, nasm, ncurses-base,
+  libnih-dbus1, libowfat-dev, libssl-dev, libz-dev, linux-libc-dev, nasm, ncurses-base,
   netpbm, ntfs-3g, parted, patchutils, perl, plymouth-label, qemu-utils,
   rsync, systemd, sysvinit-utils, tar, udev, udpcast, unzip, util-linux,
   uuid-dev, uuid-runtime, wget, wpasupplicant, zlib1g-dev, xz-utils


### PR DESCRIPTION
- The kernel was updated from version 6.7 to 6.9
- Due to the new "mainline" version 6.10, the script could no longer read the correct version
- The additional drivers 8812au and R8168 could no longer be compiled due to a changed path and a bug with kernel version 6.9
- A dependency was missing for the compilation of opentracker