### PR TITLE
Change offline check from linboserver to serverid

### DIFF
--- a/linbofs/init.sh
+++ b/linbofs/init.sh
@@ -128,7 +128,7 @@ do_env(){
     echo "export LINBOSERVER='"${SERVERID}"'" >> /.env
     export LINBOSERVER="${SERVERID}"
   fi
-  if [ -n "$LINBOSERVER" ]; then
+  if [ -n "$SERVERID" ]; then
     # add fqdn to environment
     echo "export FQDN='"${HOSTNAME}.${DOMAIN}"'" >> /.env
     export FQDN="${HOSTNAME}.${DOMAIN}"

--- a/linbofs/usr/bin/linbo_update_gui
+++ b/linbofs/usr/bin/linbo_update_gui
@@ -72,7 +72,7 @@ icons_dir="$gui_dir/icons"
 themes_dir="$gui_dir/themes"
 
 
-if [ -z "$LINBOSERVER" ]; then
+if [ -z "$SERVERID" ]; then
 
   print_status "Cannot get linbo server, continuing offline." | tee -a /tmp/linbo.log
 


### PR DESCRIPTION
If the Linbo server is specified as a kernel parameter, the environment variable LINBOSERVER is set. Since the "offline check" is based on this variable, the hostname and the Linbo GUI are not loaded from the cache partition and the fallback GUI appears.