### PR TITLE
Add --no-nvram to grub-install

### DIFF
--- a/linbofs/usr/share/linbo/shell_functions
+++ b/linbofs/usr/share/linbo/shell_functions
@@ -941,7 +941,7 @@ mk_boot(){
   # install grub in mbr/efi
   if [ ! -e "$doneflag" -a -n "$localcache" ]; then
     echo -n "Installing GRUB in MBR/EFI of $grubdisk ... "
-    grub-install --root-directory=/cache -s $grubdisk 2>> /tmp/linbo.log || RC="1"
+    grub-install --root-directory=/cache --no-nvram -s $grubdisk 2>> /tmp/linbo.log || RC="1"
     if [ "$RC" = "0" ]; then
       touch "$doneflag"
       echo "OK!"


### PR DESCRIPTION
Grub tries to install the bootloader into the NVram on newer PCs with NVram. But this fails. Hence the parameter --no-nvram to prevent this.