### PR TITLE
feat: add .driverpostsync hook support

### DIFF
--- a/linbofs/usr/bin/linbo_download_image
+++ b/linbofs/usr/bin/linbo_download_image
@@ -191,7 +191,7 @@ if [ -z "$DOWNLOAD" ]; then
 fi
 
 # download postsync and reg files in any case
-for ext in postsync reg; do
+for ext in postsync treiberpostsync reg; do
   for base in "$FILE" "$imagebase"; do
     echo -n "Trying to download ${base}.${ext} ... "
     if linbo_download "${subdir}${base}.${ext}" &> /dev/null; then

--- a/linbofs/usr/bin/linbo_download_image
+++ b/linbofs/usr/bin/linbo_download_image
@@ -191,7 +191,7 @@ if [ -z "$DOWNLOAD" ]; then
 fi
 
 # download postsync and reg files in any case
-for ext in postsync treiberpostsync reg; do
+for ext in postsync driverpostsync reg; do
   for base in "$FILE" "$imagebase"; do
     echo -n "Trying to download ${base}.${ext} ... "
     if linbo_download "${subdir}${base}.${ext}" &> /dev/null; then

--- a/linbofs/usr/bin/linbo_sync
+++ b/linbofs/usr/bin/linbo_sync
@@ -634,8 +634,8 @@ syncl(){
   [ -s "/cache/$postsync" ] && . "/cache/$postsync"
 
   # source driver postsync script (patchless driver matching)
-  local treiberpostsync="${imagebase}.treiberpostsync"
-  [ -s "/cache/$treiberpostsync" ] && . "/cache/$treiberpostsync"
+  local driverpostsync="${imagebase}.driverpostsync"
+  [ -s "/cache/$driverpostsync" ] && . "/cache/$driverpostsync"
 
   # finally do minimal boot configuration
   mk_boot || RC=1

--- a/linbofs/usr/bin/linbo_sync
+++ b/linbofs/usr/bin/linbo_sync
@@ -633,6 +633,10 @@ syncl(){
   # source postsync script
   [ -s "/cache/$postsync" ] && . "/cache/$postsync"
 
+  # source driver postsync script (patchless driver matching)
+  local treiberpostsync="${imagebase}.treiberpostsync"
+  [ -s "/cache/$treiberpostsync" ] && . "/cache/$treiberpostsync"
+
   # finally do minimal boot configuration
   mk_boot || RC=1
 


### PR DESCRIPTION
## Summary

Adds support for an optional `.driverpostsync` script, enabling patchless driver injection based on hardware profile matching without modifying the existing postsync workflow.

**Changes:**

- **`linbofs/usr/bin/linbo_sync`** — source `<imagebase>.driverpostsync` after the regular `.postsync` (same context: mounted OS at `/mnt`)
- **`linbofs/usr/bin/linbo_download_image`** — add `driverpostsync` to the download loop so the file is fetched from the server into `/cache/`

## How it works

1. A driver management tool generates `.driverpostsync` scripts per image in `/srv/linbo/images/<image>/`
2. `linbo_download_image` downloads the script to `/cache/` alongside `.postsync` and `.reg`
3. `linbo_sync` sources it after the regular postsync — drivers get copied into the synced OS

## Testing

Tested on a live linuxmuster 7.2 setup:
- Clients sync normally when no `.driverpostsync` exists (no-op, `[ -s ... ]` guard)
- When `.driverpostsync` is present, drivers are correctly injected
- No impact on existing `.postsync` behavior