### PR TITLE
fix(linbo_partition): retry umount /cache to survive concurrent re-mounts

### DIFF
--- a/linbofs/usr/bin/linbo_partition
+++ b/linbofs/usr/bin/linbo_partition
@@ -211,7 +211,13 @@ fi
 killalltorrents
 
 cd /
-mount | grep -q ' /cache ' && umount /cache &> /dev/null && sleep 3
+# Retry umount up to 10 times: linbo_gui periodically re-mounts /cache for
+# status polling, racing against a single umount + sleep.
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  mount | grep -q ' /cache ' || break
+  umount /cache &> /dev/null
+  sleep 1
+done
 if mount | grep -q ' /cache '; then
   echo "Cannot unmount /cache." >&2
   exit 1


### PR DESCRIPTION
## Symptom

`linbo-remote -i <host> -c format` (or `partition`) aborts with:

```
Cannot unmount /cache.
```

Running the same operation locally via `linbo-wrapper format` from the LINBO GUI / shell works. The bug therefore looks client-state-dependent but is in fact a timing race: it hits fast hardware (NVMe) reliably and slower hardware (HDD / older SSD) only sporadically.

## Root cause

`linbo_gui` periodically re-mounts `/cache` for status polling. On an otherwise idle client this is visible in `dmesg` as recurring cycles roughly every second:

```
EXT4-fs (nvme0n1p6): mounted filesystem ... r/w with ordered data mode.
EXT4-fs (nvme0n1p6): unmounting filesystem ...
EXT4-fs (nvme0n1p6): mounted filesystem ... ro with ordered data mode.
EXT4-fs (nvme0n1p6): unmounting filesystem ...
```

`linbo_partition` does (lines 213–218):

```sh
cd /
mount | grep -q ' /cache ' && umount /cache &> /dev/null && sleep 3
if mount | grep -q ' /cache '; then
  echo "Cannot unmount /cache." >&2
  exit 1
fi
```

The `umount` succeeds — but during the `sleep 3` the polling re-mounts `/cache`, and the subsequent `mount | grep` re-check then aborts. `gui_ctl disable`, which `linbo-remote` calls before format, hides the GUI but does not stop the status polling.

## Reproduction

- Client sitting at the LINBO GUI, `/cache` mounted.
- Watch the cycle on the client: `while :; do date '+%H:%M:%S'; mount | grep cache; sleep 0.2; done`
- Trigger from the server: `linbo-remote -i <client> -c format` — fails with `Cannot unmount /cache.`
- For comparison, in a shell on the client (Dropbear, port 2222): `linbo-wrapper format` — works.

## Fix

Replace the single `umount` + `sleep 3` with a short retry loop (up to 10 × 1 s). As soon as one iteration finds `/cache` unmounted, the loop exits and the existing failure check still fires if `/cache` is permanently busy. No new dependencies, behavior unchanged for the "not busy at all" case.

## Test

Patched `linbo_partition` via a pre-hook in `update-linbofs.pre.d` on a production linuxmuster.net 7 server (linbofs64, 4.3.33). After PXE-booting test clients, `linbo-remote -c format` runs reliably across multiple invocations and on multiple clients. No regression observed for local `linbo-wrapper format`.